### PR TITLE
Exe8.4: pcall(pcall, f) first result false is possible

### DIFF
--- a/08Compilation/pcall.lua
+++ b/08Compilation/pcall.lua
@@ -28,3 +28,37 @@ print('pcall(error, "some error code") --> ', code, err)
 outer, inner, err = pcall(pcall, error, "some error code")
 print('pcall(pcall, error, "some error code") --> ', outer, inner, err)
 
+
+--[[
+So the question is, how to raise an error to the outer pcall?
+It seems impossible, since pcall will not raise an error.
+But it only requires that the outer pcall receives an error,
+rather than the inner pcall sends one.
+Thus, if we manage to raise an error between the inner pcall
+return and the outer pcall call, the first result of the outer
+pcall will become `false`.
+So we just need to insert a function inbetween, which will raise
+an error.
+We can insert the function via `debug.sethook`.
+
+This implementation is inspired by Pierre Chapuis
+gga-users.org/lists/lua-l/2013-01/msg00577.html
+--]]
+
+function f ()
+  count = 0
+  -- the hook function
+  function g ()
+    count = count + 1
+    -- unset the hook function, otherwise when the outer pcall
+    -- returns, there will be an error, and print wont't receive
+    -- the result.
+    -- raise an error
+    if count == 2 then debug.sethook() end
+    error()
+  end
+  -- run when a function returns
+  debug.sethook(g, "r")
+end
+
+print(pcall(pcall, f))


### PR DESCRIPTION
The trick is to insert a function between two pcall,
and the inserted function will raise an error.
We can do this via `debug.sethook`.
