### PR TITLE
Update serializer.lua is_identifier regex exact

### DIFF
--- a/12DataFiles/serialize.lua
+++ b/12DataFiles/serialize.lua
@@ -31,7 +31,7 @@ function serialize(o, args)
     -- function to check if a string is a valid
     -- identifier
     local function is_identifier(id)
-        if string.match(id, "[a-zA-Z_][a-zA-Z0-9_]*") == id then
+        if string.match(id, "^[a-zA-Z_][a-zA-Z0-9_]*") == id then
             return true
         else
             return false


### PR DESCRIPTION
> Identifiers in Lua can be any string of letters, digits, and underscores, not beginning with a digit.